### PR TITLE
Added complete function, reworked link function and added tests

### DIFF
--- a/tests/test_things.py
+++ b/tests/test_things.py
@@ -232,8 +232,17 @@ class ThingsCase(unittest.TestCase):  # noqa: V103 pylint: disable=R0904
         self.assertEqual(1, len(tasks))
 
     def test_get_link(self):
-        link = things.link("uuid")
-        self.assertEqual("things:///show?id=uuid", link)
+        link = things.link("show", id="uuid")
+        self.assertEqual(
+            "things:///show?auth-token=vKkylosuSuGwxrz7qcklOw&id=uuid", link
+        )
+
+    @unittest.mock.patch("things.api.token")
+    def test_get_link_no_token(self, token_mock):
+        token_mock.return_value = None
+        with self.assertRaises(ValueError):
+            things.link("show", id="uuid")
+        self.assertEqual(token_mock.call_count, 1)
 
     def test_projects(self):
         projects = things.projects()
@@ -330,7 +339,16 @@ class ThingsCase(unittest.TestCase):  # noqa: V103 pylint: disable=R0904
     @unittest.mock.patch("os.system")
     def test_api_show(self, os_system):
         things.show("invalid_uuid")
-        os_system.assert_called_once_with("open 'things:///show?id=invalid_uuid'")
+        os_system.assert_called_once_with(
+            "open 'things:///show?auth-token=vKkylosuSuGwxrz7qcklOw&id=invalid_uuid'"
+        )
+
+    @unittest.mock.patch("os.system")
+    def test_api_complete(self, os_system):
+        things.complete("invalid_uuid")
+        os_system.assert_called_once_with(
+            "open 'things:///update?auth-token=vKkylosuSuGwxrz7qcklOw&id=invalid_uuid&completed=True'"
+        )
 
     def test_thingsdate(self):
         sqlfilter: str = things.database.make_thingsdate_filter(

--- a/tests/test_things.py
+++ b/tests/test_things.py
@@ -232,16 +232,19 @@ class ThingsCase(unittest.TestCase):  # noqa: V103 pylint: disable=R0904
         self.assertEqual(1, len(tasks))
 
     def test_get_link(self):
-        link = things.link("show", id="uuid")
-        self.assertEqual(
-            "things:///show?auth-token=vKkylosuSuGwxrz7qcklOw&id=uuid", link
-        )
+        link = things.link("uuid")
+        self.assertEqual("things:///show?id=uuid", link)
+
+    def test_get_url(self):
+        url = things.url("uuid")
+        self.assertEqual("things:///show?id=uuid", url)
 
     @unittest.mock.patch("things.api.token")
     def test_get_link_no_token(self, token_mock):
         token_mock.return_value = None
         with self.assertRaises(ValueError):
-            things.link("show", id="uuid")
+            # currently only update and update-project require authentication
+            things.link(uuid="uuid", action="update")
         self.assertEqual(token_mock.call_count, 1)
 
     def test_projects(self):
@@ -339,15 +342,13 @@ class ThingsCase(unittest.TestCase):  # noqa: V103 pylint: disable=R0904
     @unittest.mock.patch("os.system")
     def test_api_show(self, os_system):
         things.show("invalid_uuid")
-        os_system.assert_called_once_with(
-            "open 'things:///show?auth-token=vKkylosuSuGwxrz7qcklOw&id=invalid_uuid'"
-        )
+        os_system.assert_called_once_with("open 'things:///show?id=invalid_uuid'")
 
     @unittest.mock.patch("os.system")
     def test_api_complete(self, os_system):
         things.complete("invalid_uuid")
         os_system.assert_called_once_with(
-            "open 'things:///update?auth-token=vKkylosuSuGwxrz7qcklOw&id=invalid_uuid&completed=True'"
+            "open 'things:///update?id=invalid_uuid&completed=True&auth-token=vKkylosuSuGwxrz7qcklOw'"
         )
 
     def test_thingsdate(self):

--- a/tests/test_things.py
+++ b/tests/test_things.py
@@ -254,10 +254,10 @@ class ThingsCase(unittest.TestCase):  # noqa: V103 pylint: disable=R0904
         url = things.url(
             command="add",
             title="test task",
-            notes="really nice notes\nI really like notes",
+            notes="nice notes\nI really like notes",
         )
         self.assertEqual(
-            "things:///add?title=test%20task&notes=really%20nice%20notes%0AI%20really%20like%20notes",
+            "things:///add?title=test%20task&notes=nice%20notes%0AI%20really%20like%20notes",
             url,
         )
 
@@ -368,9 +368,9 @@ class ThingsCase(unittest.TestCase):  # noqa: V103 pylint: disable=R0904
 
     @unittest.mock.patch("os.system")
     def test_api_complete(self, os_system):
-        things.complete("invalid_uuid")
+        things.complete("test_uuid")
         os_system.assert_called_once_with(
-            "open 'things:///update?id=invalid_uuid&completed=True&auth-token=vKkylosuSuGwxrz7qcklOw'"
+            "open 'things:///update?id=test_uuid&completed=True&auth-token=vKkylosuSuGwxrz7qcklOw'"
         )
 
     def test_thingsdate(self):

--- a/tests/test_things.py
+++ b/tests/test_things.py
@@ -262,11 +262,11 @@ class ThingsCase(unittest.TestCase):  # noqa: V103 pylint: disable=R0904
         )
 
     @unittest.mock.patch("things.api.token")
-    def test_get_link_no_token(self, token_mock):
+    def test_get_url_no_token(self, token_mock):
         token_mock.return_value = None
         with self.assertRaises(ValueError):
             # currently only update and update-project require authentication
-            things.url(uuid="uuid", command="update")
+            things.url(command="update")
         self.assertEqual(token_mock.call_count, 1)
 
     def test_projects(self):

--- a/tests/test_things.py
+++ b/tests/test_things.py
@@ -239,12 +239,23 @@ class ThingsCase(unittest.TestCase):  # noqa: V103 pylint: disable=R0904
         url = things.url("uuid")
         self.assertEqual("things:///show?id=uuid", url)
 
+    def test_get_url_encoding(self):
+        url = things.url(
+            command="add",
+            title="test task",
+            notes="really nice notes\nI really like notes",
+        )
+        self.assertEqual(
+            "things:///add?title=test%20task&notes=really%20nice%20notes%0AI%20really%20like%20notes",
+            url,
+        )
+
     @unittest.mock.patch("things.api.token")
     def test_get_link_no_token(self, token_mock):
         token_mock.return_value = None
         with self.assertRaises(ValueError):
             # currently only update and update-project require authentication
-            things.link(uuid="uuid", action="update")
+            things.url(uuid="uuid", command="update")
         self.assertEqual(token_mock.call_count, 1)
 
     def test_projects(self):

--- a/tests/test_things.py
+++ b/tests/test_things.py
@@ -239,6 +239,17 @@ class ThingsCase(unittest.TestCase):  # noqa: V103 pylint: disable=R0904
         url = things.url("uuid")
         self.assertEqual("things:///show?id=uuid", url)
 
+    def test_get_url_dict(self):
+        parameters = {
+            "title": "nice_title",
+            "list-id": "6c7e77b4-f4d7-44bc-8480-80c0bea585ea",
+        }
+        url = things.url(command="add", **parameters)
+        self.assertEqual(
+            "things:///add?title=nice_title&list-id=6c7e77b4-f4d7-44bc-8480-80c0bea585ea",
+            url,
+        )
+
     def test_get_url_encoding(self):
         url = things.url(
             command="add",

--- a/things/__init__.py
+++ b/things/__init__.py
@@ -14,6 +14,7 @@ from things.api import (  # noqa  isort:skip
     areas,
     canceled,
     checklist_items,
+    complete,
     completed,
     deadlines,
     get,

--- a/things/__init__.py
+++ b/things/__init__.py
@@ -33,6 +33,7 @@ from things.api import (  # noqa  isort:skip
     token,
     trash,
     upcoming,
+    url,
 )
 
 from things.database import Database  # noqa

--- a/things/api.py
+++ b/things/api.py
@@ -677,9 +677,26 @@ def token(**kwargs) -> Union[str, None]:
     return database.get_url_scheme_auth_token()
 
 
-def link(uuid):
-    """Return a things:///show?id=uuid link."""
-    return f"things:///show?id={uuid}"
+def link(action, **kwargs) -> str:
+    """
+    Return a things:///<action>?auth-token=<token>(&<query_params>) link.
+
+    Additional query parameters can be provided in **kwargs
+
+    Detailed information about the Things URL Scheme can be found
+    [here](https://culturedcode.com/things/help/url-scheme/).
+
+    The returned link can be called with
+    >>> os.system(f"open {quote(link)}") # doctest: +SKIP
+    """
+    auth_token = token()
+    if auth_token is None:
+        raise ValueError("Things URL scheme authentication token could not be read")
+    uri = f"things:///{action}?auth-token={auth_token}"
+    for key, value in kwargs.items():
+        uri += f"&{key}={value}"
+
+    return uri
 
 
 def show(uuid):  # noqa
@@ -696,7 +713,25 @@ def show(uuid):  # noqa
     >>> tag = things.tags('Home')
     >>> things.show(tag['uuid'])  # doctest: +SKIP
     """
-    uri = link(uuid)
+    uri = link("show", id=uuid)
+    os.system(f"open {quote(uri)}")
+
+
+def complete(uuid):  # noqa
+    """
+    Set the status of a certain uuid to complete
+
+    Parameters
+    ----------
+    uuid : str
+        A valid uuid of a project or todo.
+
+    Examples
+    --------
+    >>> task = things.todos()[0]       # doctest: +SKIP
+    >>> things.complete(task['uuid'])  # doctest: +SKIP
+    """
+    uri = link("update", id=uuid, completed=True)
     os.system(f"open {quote(uri)}")
 
 

--- a/things/api.py
+++ b/things/api.py
@@ -10,7 +10,9 @@ data structures. Whenever that happens, we define the new term here.
 import os
 from shlex import quote
 from typing import Dict, List, Union
+
 import urllib.parse
+
 from things.database import Database
 
 
@@ -687,16 +689,16 @@ def url(uuid=None, command="show", **kwargs) -> str:
 
     Parameters
     ----------
-    uuid : str, optional
-        A valid uuid of any Things object
-        Defaults to None
+    uuid : str or None, optional
+        A valid uuid of any Things object.
+        If None id is not added as a parameter.
 
-    action : str, optional
-        A valid thingsURL command
-        Defaults to show
+    action : str, default show
+        A valid thingsURL command.
 
     **kwargs:
         Any aditional parameters needed.
+        Passing a dictionary is valid aswell.
 
     Examples
     --------
@@ -706,8 +708,11 @@ def url(uuid=None, command="show", **kwargs) -> str:
     'things:///update?id=test_uuid&title=new%20title&auth-token=vKkylosuSuGwxrz7qcklOw'
     >>> things.url(command="add", title="new task", when="in 3 days", deadline="in 6 days")
     'things:///add?title=new%20task&when=in%203%20days&deadline=in%206%20days'
+    >>> parameters = {"title" : "test title", "list-id" : "ba5d1237-1dfa-4ab8-826b-7c27b517f29d"}
+    >>> things.url(command="add", **parameters)
+    'things:///add?title=test%20title&list-id=ba5d1237-1dfa-4ab8-826b-7c27b517f29d'
     """
-    query_params = dict(**kwargs) if uuid is None else dict(id=uuid, **kwargs)
+    query_params = dict(kwargs) if uuid is None else dict(id=uuid, **kwargs)
 
     # authenticate if needed
     if command not in ("add", "add-project", "show", "search", "json"):

--- a/things/api.py
+++ b/things/api.py
@@ -681,6 +681,10 @@ def url(uuid=None, command="show", **kwargs) -> str:
     """
     Return a things:///<command>?id=uuid&… url.
 
+    For details about available commands and their parameters
+    consult the Things URL Scheme documentation
+    [here](https://culturedcode.com/things/help/url-scheme/).
+
     Parameters
     ----------
     uuid : str, optional
@@ -693,10 +697,6 @@ def url(uuid=None, command="show", **kwargs) -> str:
 
     **kwargs:
         Any aditional parameters needed.
-
-    For details about availabel commands and their parameters
-    consult the Things URL Scheme documentation
-    [here](https://culturedcode.com/things/help/url-scheme/).
 
     Examples
     --------

--- a/things/api.py
+++ b/things/api.py
@@ -707,12 +707,12 @@ def url(uuid=None, command="show", **query_parameters) -> str:
     'things:///update?id=6Hf2qWBjWhq7B1xszwdo34&title=new%20title&auth-token=vKkylosuSuGwxrz7qcklOw'
     >>> things.url(command='add', title='new task', when='in 3 days', deadline='in 6 days')
     'things:///add?title=new%20task&when=in%203%20days&deadline=in%206%20days'
-    >>> query_parameters = {'title': 'test title', 'list-id': 'ba5d1237-1dfa-4ab8-826b-7c27b517f29d'}
-    >>> things.url(command="add", **query_parameters)
+    >>> query_params = {'title': 'test title', 'list-id': 'ba5d1237-1dfa-4ab8-826b-7c27b517f29d'}
+    >>> things.url(command="add", **query_params)
     'things:///add?title=test%20title&list-id=ba5d1237-1dfa-4ab8-826b-7c27b517f29d'
     """
     if uuid is not None:
-        query_parameters = dict(id=uuid, **query_parameters)
+        query_parameters = {"id": uuid, **query_parameters}
 
     # authenticate if needed
     if command in ("update", "update-project"):

--- a/things/api.py
+++ b/things/api.py
@@ -10,7 +10,6 @@ data structures. Whenever that happens, we define the new term here.
 import os
 from shlex import quote
 from typing import Dict, List, Union
-
 import urllib.parse
 
 from things.database import Database

--- a/things/api.py
+++ b/things/api.py
@@ -692,7 +692,7 @@ def url(uuid=None, command="show", **kwargs) -> str:
         A valid uuid of any Things object.
         If None id is not added as a parameter.
 
-    action : str, default show
+    command : str, default show
         A valid thingsURL command.
 
     **kwargs:

--- a/things/api.py
+++ b/things/api.py
@@ -700,9 +700,12 @@ def url(uuid=None, command="show", **kwargs) -> str:
 
     Examples
     --------
-    >>> things_url_show = things.url("test_uuid")
-    >>> things_url_update = things.url(command="update", uuid="test_uuid", title="new title")
-    >>> things_url_add = things.url(command="add", title="new task", when="in 3 days", deadline="in 6 days")
+    >>> things.url("test_uuid")
+    'things:///show?id=test_uuid'
+    >>> things.url(command="update", uuid="test_uuid", title="new title")
+    'things:///update?id=test_uuid&title=new%20title&auth-token=vKkylosuSuGwxrz7qcklOw'
+    >>> things.url(command="add", title="new task", when="in 3 days", deadline="in 6 days")
+    'things:///add?title=new%20task&when=in%203%20days&deadline=in%206%20days'
     """
     query_params = dict(**kwargs) if uuid is None else dict(id=uuid, **kwargs)
 

--- a/things/database.py
+++ b/things/database.py
@@ -1045,7 +1045,8 @@ def make_unixtime_range_filter(date_column: str, offset) -> str:
         modifier = f"-{number} years"
 
     column_datetime = f"datetime({date_column}, 'unixepoch')"
-    offset_datetime = f"datetime('now', '{modifier}')"  # type: ignore
+    offset_datetime = f"datetime('now', '{modifier}')" \
+        # pylint: disable=E0606; # type: ignore
 
     return f"AND {column_datetime} > {offset_datetime}"
 

--- a/things/database.py
+++ b/things/database.py
@@ -1043,10 +1043,11 @@ def make_unixtime_range_filter(date_column: str, offset) -> str:
         modifier = f"-{number * 7} days"
     elif suffix == "y":
         modifier = f"-{number} years"
+    else:
+        raise ValueError()  # for pylint; `validate_offset` already checks this
 
     column_datetime = f"datetime({date_column}, 'unixepoch')"
-    offset_datetime = f"datetime('now', '{modifier}')" \
-        # pylint: disable=E0606; # type: ignore
+    offset_datetime = f"datetime('now', '{modifier}')"
 
     return f"AND {column_datetime} > {offset_datetime}"
 

--- a/things/database.py
+++ b/things/database.py
@@ -1,4 +1,5 @@
 """Read from the Things SQLite database using SQL queries."""
+
 # pylint: disable=C0302
 
 import datetime


### PR DESCRIPTION
#### Motivation
I am working on a project that syncs Things3 with reclaim.ai.
For this I needed a way to programmatically complete a things task.

#### Changes made:
Added the complete function to programmatically complete a things task/project using the Things URL Scheme.

Modified the link function to a more general version
   - Changed hardcoded "show" action to a variable
   - every link now contains the auth_token query argument
   - additional query arguments can now be supplied using **kwargs

Modified the show function to account for the updated link function

Added test for complete function and modified tests for link function to account for the updated link function