### PR TITLE
Temporary/throwaway PR to recheck that the resource warning for DB reuse is still active with current version

### DIFF
--- a/things/database.py
+++ b/things/database.py
@@ -168,7 +168,6 @@ class Database:
     """
 
     debug = False
-    connection: sqlite3.Connection
 
     # pylint: disable=R0913
     def __init__(self, filepath=None, print_sql=False):
@@ -181,11 +180,6 @@ class Database:
         self.print_sql = print_sql
         if self.print_sql:
             self.execute_query_count = 0
-
-        # "ro" means read-only
-        # See: https://sqlite.org/uri.html#recognized_query_parameters
-        uri = f"file:{self.filepath}?mode=ro"
-        self.connection = sqlite3.connect(uri, uri=True)  # pylint: disable=E1101
 
         # Test for migrated database in Things 3.15.16+
         # --------------------------------
@@ -501,14 +495,17 @@ class Database:
             print(prettify_sql(sql_query))
             print()
 
-        with self.connection:
-            # Using context manager to keep queries in separate transactions,
-            # see https://docs.python.org/3/library/sqlite3.html#sqlite3-connection-context-manager
-            self.connection.row_factory = row_factory or dict_factory
-            cursor = self.connection.cursor()
-            cursor.execute(sql_query, parameters)
+        # "ro" means read-only
+        # See: https://sqlite.org/uri.html#recognized_query_parameters
+        uri = f"file:{self.filepath}?mode=ro"
+        connection = sqlite3.connect(uri, uri=True)  # pylint: disable=E1101
+        connection.row_factory = row_factory or dict_factory
+        cursor = connection.cursor()
+        cursor.execute(sql_query, parameters)
 
-            return cursor.fetchall()
+        result = cursor.fetchall()
+        connection.close()
+        return result
 
 
 # Helper functions

--- a/things/database.py
+++ b/things/database.py
@@ -10,6 +10,7 @@ import re
 import sqlite3
 from textwrap import dedent
 from typing import Optional, Union
+import weakref
 
 
 # --------------------------------------------------
@@ -186,6 +187,7 @@ class Database:
         # See: https://sqlite.org/uri.html#recognized_query_parameters
         uri = f"file:{self.filepath}?mode=ro"
         self.connection = sqlite3.connect(uri, uri=True)  # pylint: disable=E1101
+        self._finalizer = weakref.finalize(self, self._close_connection)
 
         # Test for migrated database in Things 3.15.16+
         # --------------------------------
@@ -509,6 +511,10 @@ class Database:
             cursor.execute(sql_query, parameters)
 
             return cursor.fetchall()
+
+    def _close_connection(self):
+        """Close the database connection."""
+        self.connection.close()
 
 
 # Helper functions


### PR DESCRIPTION
Before committing to backing out that connection reuse commit, reassert that the CI test failure is still active with the current version of Python, things.py, and its dependencies.

If this still fails tests in CI, I'll delete/discard this PR. Otherwise, I'll suggest leaving the connection reuse commit in place.