### PR TITLE
Update README.md with link to things.http

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The following open-source projects make use of this library:
 - [Things to OmniFocus via TaskPaper (wolf)](https://github.com/wolf/export-things-to-taskpaper)
 - [Things to Org file (chrizel)](https://github.com/chrizel/things-to-org)
 - [Things to Reclaim (cato447)](https://github.com/cato447/things2reclaim)
+- [Things.http (ehippy)](https://github.com/ehippy/things.http)
 - [CLI for Things](https://github.com/thingsapi/things-cli)
 - [GTD-like Reviews (minthemiddle)](https://github.com/minthemiddle/things-review-py)
 - [KanbanView for Things (AlexanderWillner)](https://github.com/AlexanderWillner/KanbanView)


### PR DESCRIPTION
Things.py is great! But I wanted to use it from a computer that wasn't a mac. 

Things.http wraps things.py with a http basic auth via FastAPI, and offers a system daemon template to have the lil mac mini at home offer up one's things database to friendly local api consumers.

Great project!